### PR TITLE
chore: jms configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ MYSQL_USER='beer_service'
 MYSQL_PASSWORD='secret'
 DB_HOST='beer-service-database'
 DB_HOST_PORT=3306
+
+# jms
+JMS_USER='jms_user'
+JMS_PASSWORD='jms_secret'
+JMS_INITIAL_SENDER=false

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.egon</groupId>
 		<artifactId>mssc-brewery-bom</artifactId>
-		<version>1.1.0</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<groupId>com.egon</groupId>
@@ -33,10 +33,6 @@
 			<artifactId>ehcache</artifactId>
 			<classifier>jakarta</classifier>
 			<version>${ehcache.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-artemis</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,9 @@
 			<classifier>jakarta</classifier>
 			<version>${ehcache.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-artemis</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/egon/msscbeerservice/config/JmsConfig.java
+++ b/src/main/java/com/egon/msscbeerservice/config/JmsConfig.java
@@ -1,0 +1,39 @@
+package com.egon.msscbeerservice.config;
+
+import jakarta.jms.ConnectionFactory;
+import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.MessageType;
+
+/**
+ * <a href="https://spring.io/guides/gs/messaging-jms">Spring Messaging JMS guide</a>
+ */
+@EnableJms
+@Configuration
+public class JmsConfig {
+
+  public static final String QUEUE_A = "queue_a";
+
+  @Bean
+  public JmsListenerContainerFactory<?> myFactory(
+      ConnectionFactory connectionFactory,
+      DefaultJmsListenerContainerFactoryConfigurer configurer) {
+    DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+    configurer.configure(factory, connectionFactory);
+    return factory;
+  }
+
+  @Bean // Serialize message content to json using TextMessage
+  public MessageConverter jacksonJmsMessageConverter() {
+    MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+    converter.setTargetType(MessageType.TEXT);
+    converter.setTypeIdPropertyName("_type");
+    return converter;
+  }
+}

--- a/src/main/java/com/egon/msscbeerservice/config/TaskConfig.java
+++ b/src/main/java/com/egon/msscbeerservice/config/TaskConfig.java
@@ -1,0 +1,19 @@
+package com.egon.msscbeerservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@EnableAsync
+@Configuration
+public class TaskConfig {
+
+  @Bean
+  TaskExecutor taskExecutor() {
+    return new SimpleAsyncTaskExecutor();
+  }
+}

--- a/src/main/java/com/egon/msscbeerservice/jms/dtos/HelloMessageDto.java
+++ b/src/main/java/com/egon/msscbeerservice/jms/dtos/HelloMessageDto.java
@@ -1,0 +1,19 @@
+package com.egon.msscbeerservice.jms.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HelloMessageDto  implements Serializable {
+
+  private UUID id;
+  private String message;
+}

--- a/src/main/java/com/egon/msscbeerservice/jms/listeners/HelloMessageListener.java
+++ b/src/main/java/com/egon/msscbeerservice/jms/listeners/HelloMessageListener.java
@@ -1,0 +1,18 @@
+package com.egon.msscbeerservice.jms.listeners;
+
+import com.egon.msscbeerservice.config.JmsConfig;
+import com.egon.msscbeerservice.jms.dtos.HelloMessageDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class HelloMessageListener {
+
+  @JmsListener(destination = JmsConfig.QUEUE_A, containerFactory = "myFactory")
+  public void listen(HelloMessageDto messageDto, MessageHeaders headers) {
+    log.info("Message received: {}", messageDto);
+  }
+}

--- a/src/main/java/com/egon/msscbeerservice/jms/senders/HelloMessageSender.java
+++ b/src/main/java/com/egon/msscbeerservice/jms/senders/HelloMessageSender.java
@@ -1,7 +1,7 @@
 package com.egon.msscbeerservice.jms.senders;
 
-import com.egon.msscbeerservice.jms.dtos.HelloMessageDto;
 import com.egon.msscbeerservice.config.JmsConfig;
+import com.egon.msscbeerservice.jms.dtos.HelloMessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/egon/msscbeerservice/jms/senders/HelloMessageSender.java
+++ b/src/main/java/com/egon/msscbeerservice/jms/senders/HelloMessageSender.java
@@ -1,0 +1,37 @@
+package com.egon.msscbeerservice.jms.senders;
+
+import com.egon.msscbeerservice.jms.dtos.HelloMessageDto;
+import com.egon.msscbeerservice.config.JmsConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class HelloMessageSender {
+
+  @Value("${beer.jms.initial.sender}")
+  private Boolean shouldSend;
+
+  private final JmsTemplate jmsTemplate;
+
+  @Scheduled(fixedRate = 5000)
+  public void send() {
+    if (Objects.isNull(shouldSend) || Boolean.FALSE.equals(shouldSend)) return;
+
+    var message = HelloMessageDto.builder()
+        .id(UUID.randomUUID())
+        .message("Hello from JMS")
+        .build();
+    log.info("sending jms message with id {}...", message.getId().toString());
+    jmsTemplate.convertAndSend(JmsConfig.QUEUE_A, message);
+  }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,4 +22,10 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 # log web, jpa transactions, etc
 # logging.level.org.springframework=trace
 
+# jms
+spring.artemis.user=${JMS_USER}
+spring.artemis.password=${JMS_PASSWORD}
+
+# app
 beer.inventory.service.host=http://localhost:8082
+beer.jms.initial.sender=${JMS_INITIAL_SENDER}

--- a/src/test/java/com/egon/msscbeerservice/MsscBeerServiceApplicationTests.java
+++ b/src/test/java/com/egon/msscbeerservice/MsscBeerServiceApplicationTests.java
@@ -1,7 +1,9 @@
 package com.egon.msscbeerservice;
 
 import com.egon.msscbeerservice.beer.services.GetOnHandBeerInventoryService;
+import jakarta.jms.ConnectionFactory;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.CacheManager;
@@ -30,4 +32,11 @@ class MsscBeerServiceApplicationTests {
 		}
 	}
 
+	@Configuration
+	public static class JMSTestConfig {
+		@Bean
+		public ConnectionFactory connectionFactory() {
+			return Mockito.mock(ConnectionFactory.class);
+		}
+	}
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 spring.sql.init.mode=never
+beer.jms.initial.sender=false


### PR DESCRIPTION
You can use the ActiveMQ Artemis from [this repo](https://github.com/egon89/docker-mono-repo/tree/main/activemq-artemis).
ActiveMQ Web Console: http://localhost:8161

We need of the **spring-boot-starter-artemis** dependency. It was included in [POM parent](https://github.com/egon89/mssc-brewery-bom/commit/10d1f164c74ef89b6af05c9caf5fd91df8f72098).

Set the env variable `JMS_INITIAL_SENDER` to false to not run the sender's task scheduled.

:grey_exclamation: When the listener throws an exception, the message will be send to DLQ.