### PR TITLE
refactor: common event package

### DIFF
--- a/src/main/java/com/egon/common/events/dtos/EventDto.java
+++ b/src/main/java/com/egon/common/events/dtos/EventDto.java
@@ -1,4 +1,4 @@
-package com.egon.msscbeerservice.shared.dtos;
+package com.egon.common.events.dtos;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/egon/common/events/dtos/LowInventoryBeerEventDto.java
+++ b/src/main/java/com/egon/common/events/dtos/LowInventoryBeerEventDto.java
@@ -1,7 +1,6 @@
-package com.egon.msscbeerservice.beer.dtos.events;
+package com.egon.common.events.dtos;
 
 import com.egon.msscbeerservice.beer.dtos.BeerDto;
-import com.egon.msscbeerservice.shared.dtos.EventDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,14 +11,14 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class BeerEventDto extends EventDto<BeerEventDto.LowInventoryBeerDto> {
+public class LowInventoryBeerEventDto extends EventDto<LowInventoryBeerEventDto.LowInventoryBeerDto> {
   @Builder
-  public BeerEventDto(LowInventoryBeerDto data) {
+  public LowInventoryBeerEventDto(LowInventoryBeerDto data) {
     super(data);
   }
 
-  public static BeerEventDto create(BeerDto beerDto) {
-    return BeerEventDto.builder()
+  public static LowInventoryBeerEventDto create(BeerDto beerDto) {
+    return LowInventoryBeerEventDto.builder()
         .data(new LowInventoryBeerDto(beerDto.getId(), beerDto.getQuantityOnHand(), beerDto.getMinOnHand()))
         .build();
   }

--- a/src/main/java/com/egon/common/events/dtos/NewInventoryEventDto.java
+++ b/src/main/java/com/egon/common/events/dtos/NewInventoryEventDto.java
@@ -1,6 +1,5 @@
-package com.egon.msscbeerservice.beer.dtos.events;
+package com.egon.common.events.dtos;
 
-import com.egon.msscbeerservice.shared.dtos.EventDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/com/egon/msscbeerservice/beer/listeners/BrewBeerListener.java
+++ b/src/main/java/com/egon/msscbeerservice/beer/listeners/BrewBeerListener.java
@@ -1,7 +1,7 @@
 package com.egon.msscbeerservice.beer.listeners;
 
-import com.egon.msscbeerservice.beer.dtos.events.BeerEventDto;
+import com.egon.common.events.dtos.LowInventoryBeerEventDto;
 
 public interface BrewBeerListener {
-  void listen(BeerEventDto eventDto);
+  void listen(LowInventoryBeerEventDto eventDto);
 }

--- a/src/main/java/com/egon/msscbeerservice/beer/listeners/impl/BrewBeerListenerImpl.java
+++ b/src/main/java/com/egon/msscbeerservice/beer/listeners/impl/BrewBeerListenerImpl.java
@@ -1,7 +1,7 @@
 package com.egon.msscbeerservice.beer.listeners.impl;
 
-import com.egon.msscbeerservice.beer.dtos.events.BeerEventDto;
-import com.egon.msscbeerservice.beer.dtos.events.NewInventoryEventDto;
+import com.egon.common.events.dtos.LowInventoryBeerEventDto;
+import com.egon.common.events.dtos.NewInventoryEventDto;
 import com.egon.msscbeerservice.beer.listeners.BrewBeerListener;
 import com.egon.msscbeerservice.beer.repositories.BeerRepository;
 import com.egon.msscbeerservice.config.JmsConfig;
@@ -11,13 +11,13 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.jms.core.JmsTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
-@Service
+@Component
 public class BrewBeerListenerImpl implements BrewBeerListener {
 
   private final BeerRepository beerRepository;
@@ -25,7 +25,7 @@ public class BrewBeerListenerImpl implements BrewBeerListener {
 
   @JmsListener(destination = JmsConfig.BREWING_REQUEST_QUEUE)
   @Override
-  public void listen(BeerEventDto eventDto) {
+  public void listen(LowInventoryBeerEventDto eventDto) {
     val beerDto = Optional.of(eventDto.getData()).orElseThrow(IllegalArgumentException::new);
     log.debug("Get beer {} listening queue {}", beerDto.id(), JmsConfig.BREWING_REQUEST_QUEUE);
     val beer = beerRepository.findById(beerDto.id()).orElseThrow(NotFoundException::new);

--- a/src/main/java/com/egon/msscbeerservice/beer/services/impl/CheckForLowInventoryImpl.java
+++ b/src/main/java/com/egon/msscbeerservice/beer/services/impl/CheckForLowInventoryImpl.java
@@ -1,6 +1,6 @@
 package com.egon.msscbeerservice.beer.services.impl;
 
-import com.egon.msscbeerservice.beer.dtos.events.BeerEventDto;
+import com.egon.common.events.dtos.LowInventoryBeerEventDto;
 import com.egon.msscbeerservice.beer.mappers.BeerMapper;
 import com.egon.msscbeerservice.beer.repositories.BeerRepository;
 import com.egon.msscbeerservice.beer.services.CheckForLowInventory;
@@ -41,7 +41,7 @@ public class CheckForLowInventoryImpl implements CheckForLowInventory {
         .forEach(beerDto -> {
           log.info("[!] Low local inventory for beer {}. Local inventory: {}. Minimum required: {}.",
               beerDto.getId(), beerDto.getQuantityOnHand(), beerDto.getMinOnHand());
-          jmsTemplate.convertAndSend(JmsConfig.BREWING_REQUEST_QUEUE, BeerEventDto.create(beerDto));
+          jmsTemplate.convertAndSend(JmsConfig.BREWING_REQUEST_QUEUE, LowInventoryBeerEventDto.create(beerDto));
           log.debug("Beer {} sent to queue {}", beerDto.getId(), JmsConfig.BREWING_REQUEST_QUEUE);
         });
     log.debug("Check for low inventory job finished");


### PR DESCRIPTION
The event DTOs must have a common full qualified name for all projects.
The `common.*` package should contains only the DTOs. Don't create any Spring component into it because this package is not in the Spring scan.