### PR TITLE
feat: configure eureka client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<java.version>17</java.version>
 		<cache-api.version>1.1.1</cache-api.version>
 		<ehcache.version>3.10.8</ehcache.version>
+		<spring-cloud.version>2023.0.1</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -34,5 +35,20 @@
 			<classifier>jakarta</classifier>
 			<version>${ehcache.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.egon</groupId>
 		<artifactId>mssc-brewery-bom</artifactId>
-		<version>1.3.0</version>
+		<version>1.5.0</version>
 	</parent>
 
 	<groupId>com.egon</groupId>

--- a/src/main/java/com/egon/msscbeerservice/config/LocalDiscovery.java
+++ b/src/main/java/com/egon/msscbeerservice/config/LocalDiscovery.java
@@ -1,0 +1,11 @@
+package com.egon.msscbeerservice.config;
+
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("local-discovery")
+@EnableDiscoveryClient
+@Configuration
+public class LocalDiscovery {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.application.name=beer-service
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 spring.datasource.driver-class-name=org.h2.Driver


### PR DESCRIPTION
- Eureka server running after eureka client configured in beer-service
![image](https://github.com/egon89/mssc-beer-service/assets/8801502/d0c8f5a2-1449-4b42-b21d-3647faaa215d)

- Need to run with `local-discovery` profile
![image](https://github.com/egon89/mssc-beer-service/assets/8801502/81c854e2-27fd-4981-8197-9344294abd6c)

- It was necessary to update Spring version to 3.2.6 (done in bom parent 1.5.0)